### PR TITLE
Add clients and testimonials sections with case detail pages

### DIFF
--- a/caso-proyecto1.html
+++ b/caso-proyecto1.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width" />
+  <title>Proyecto 1 - W AGENCY</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+<div class="app">
+  <header class="header">
+    <nav class="nav container">
+      <a href="index.html" class="logo">W AGENCY</a>
+      <ul class="links">
+        <li><a href="index.html#servicios">Servicios</a></li>
+        <li><a href="index.html#portfolio">Portfolio</a></li>
+        <li><a href="index.html#contacto">Contacto</a></li>
+      </ul>
+      <a href="index.html#contacto" class="btn btn-outline">¡Quiero!</a>
+    </nav>
+  </header>
+
+  <section class="section container">
+    <h1 class="section-title">Proyecto 1</h1>
+    <p class="muted">Campaña integral de lanzamiento para una startup tecnológica.</p>
+    <img src="https://images.unsplash.com/photo-1522199710521-72d69614c702?auto=format&fit=crop&w=1200&q=80" alt="Proyecto 1" style="width:100%;border-radius:16px;margin:20px 0;">
+    <div class="grid">
+      <div class="card">
+        <div class="card-title">Desafío</div>
+        <p class="card-text">La marca necesitaba posicionarse en un mercado competitivo y generar expectativa antes del lanzamiento.</p>
+      </div>
+      <div class="card">
+        <div class="card-title">Estrategia</div>
+        <p class="card-text">Diseñamos una identidad sólida, activamos campañas en redes y colaboramos con influencers del sector.</p>
+      </div>
+      <div class="card">
+        <div class="card-title">Resultados</div>
+        <p class="card-text">En tres meses se lograron más de 50.000 registros y un incremento del 300% en visitas al sitio.</p>
+      </div>
+    </div>
+    <p class="muted" style="margin-top:20px"><a class="project-link" href="index.html#portfolio">← Volver al portfolio</a></p>
+  </section>
+
+  <footer class="footer">
+    <div class="container footer-row">
+      <div>
+        <div class="logo">W AGENCY</div>
+        <div class="tiny muted">© 2025 · Todos los derechos reservados</div>
+      </div>
+      <div class="tiny muted right">Hecho con HTML + CSS</div>
+    </div>
+  </footer>
+</div>
+</body>
+</html>

--- a/caso-proyecto2.html
+++ b/caso-proyecto2.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width" />
+  <title>Proyecto 2 - W AGENCY</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+<div class="app">
+  <header class="header">
+    <nav class="nav container">
+      <a href="index.html" class="logo">W AGENCY</a>
+      <ul class="links">
+        <li><a href="index.html#servicios">Servicios</a></li>
+        <li><a href="index.html#portfolio">Portfolio</a></li>
+        <li><a href="index.html#contacto">Contacto</a></li>
+      </ul>
+      <a href="index.html#contacto" class="btn btn-outline">¡Quiero!</a>
+    </nav>
+  </header>
+
+  <section class="section container">
+    <h1 class="section-title">Proyecto 2</h1>
+    <p class="muted">Estrategia de e-commerce y performance para una marca fitness.</p>
+    <img src="https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=1200&q=80" alt="Proyecto 2" style="width:100%;border-radius:16px;margin:20px 0;">
+    <div class="grid">
+      <div class="card">
+        <div class="card-title">Desafío</div>
+        <p class="card-text">El sitio recibía tráfico, pero las conversiones eran bajas y el costo por adquisición elevado.</p>
+      </div>
+      <div class="card">
+        <div class="card-title">Estrategia</div>
+        <p class="card-text">Optimizamos la tienda, lanzamos campañas segmentadas y creamos contenido orientado a la conversión.</p>
+      </div>
+      <div class="card">
+        <div class="card-title">Resultados</div>
+        <p class="card-text">Se duplicó la tasa de conversión y el retorno de inversión publicitaria alcanzó 5x.</p>
+      </div>
+    </div>
+    <p class="muted" style="margin-top:20px"><a class="project-link" href="index.html#portfolio">← Volver al portfolio</a></p>
+  </section>
+
+  <footer class="footer">
+    <div class="container footer-row">
+      <div>
+        <div class="logo">W AGENCY</div>
+        <div class="tiny muted">© 2025 · Todos los derechos reservados</div>
+      </div>
+      <div class="tiny muted right">Hecho con HTML + CSS</div>
+    </div>
+  </footer>
+</div>
+</body>
+</html>

--- a/caso-proyecto3.html
+++ b/caso-proyecto3.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width" />
+  <title>Proyecto 3 - W AGENCY</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+<div class="app">
+  <header class="header">
+    <nav class="nav container">
+      <a href="index.html" class="logo">W AGENCY</a>
+      <ul class="links">
+        <li><a href="index.html#servicios">Servicios</a></li>
+        <li><a href="index.html#portfolio">Portfolio</a></li>
+        <li><a href="index.html#contacto">Contacto</a></li>
+      </ul>
+      <a href="index.html#contacto" class="btn btn-outline">¡Quiero!</a>
+    </nav>
+  </header>
+
+  <section class="section container">
+    <h1 class="section-title">Proyecto 3</h1>
+    <p class="muted">Cobertura digital para un evento gamer con miles de asistentes.</p>
+    <img src="https://images.unsplash.com/photo-1542744095-fcf48d80b0fd?auto=format&fit=crop&w=1200&q=80" alt="Proyecto 3" style="width:100%;border-radius:16px;margin:20px 0;">
+    <div class="grid">
+      <div class="card">
+        <div class="card-title">Desafío</div>
+        <p class="card-text">Se buscaba generar ruido en redes y asegurar una alta asistencia al evento presencial.</p>
+      </div>
+      <div class="card">
+        <div class="card-title">Estrategia</div>
+        <p class="card-text">Planificamos contenido diario, transmisiones en vivo y anuncios geolocalizados.</p>
+      </div>
+      <div class="card">
+        <div class="card-title">Resultados</div>
+        <p class="card-text">Más de 20.000 asistentes y cobertura mediática en los principales portales del país.</p>
+      </div>
+    </div>
+    <p class="muted" style="margin-top:20px"><a class="project-link" href="index.html#portfolio">← Volver al portfolio</a></p>
+  </section>
+
+  <footer class="footer">
+    <div class="container footer-row">
+      <div>
+        <div class="logo">W AGENCY</div>
+        <div class="tiny muted">© 2025 · Todos los derechos reservados</div>
+      </div>
+      <div class="tiny muted right">Hecho con HTML + CSS</div>
+    </div>
+  </footer>
+</div>
+</body>
+</html>

--- a/caso-proyecto4.html
+++ b/caso-proyecto4.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width" />
+  <title>Proyecto 4 - W AGENCY</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+<div class="app">
+  <header class="header">
+    <nav class="nav container">
+      <a href="index.html" class="logo">W AGENCY</a>
+      <ul class="links">
+        <li><a href="index.html#servicios">Servicios</a></li>
+        <li><a href="index.html#portfolio">Portfolio</a></li>
+        <li><a href="index.html#contacto">Contacto</a></li>
+      </ul>
+      <a href="index.html#contacto" class="btn btn-outline">¡Quiero!</a>
+    </nav>
+  </header>
+
+  <section class="section container">
+    <h1 class="section-title">Proyecto 4</h1>
+    <p class="muted">Rebranding completo y posicionamiento digital para una empresa de servicios.</p>
+    <img src="https://images.unsplash.com/photo-1556761175-4b46a572b786?auto=format&fit=crop&w=1200&q=80" alt="Proyecto 4" style="width:100%;border-radius:16px;margin:20px 0;">
+    <div class="grid">
+      <div class="card">
+        <div class="card-title">Desafío</div>
+        <p class="card-text">El negocio necesitaba modernizar su imagen sin perder reconocimiento de marca.</p>
+      </div>
+      <div class="card">
+        <div class="card-title">Estrategia</div>
+        <p class="card-text">Actualizamos el branding, renovamos la web e implementamos campañas de notoriedad.</p>
+      </div>
+      <div class="card">
+        <div class="card-title">Resultados</div>
+        <p class="card-text">El tráfico orgánico creció 120% y la tasa de retención aumentó notablemente.</p>
+      </div>
+    </div>
+    <p class="muted" style="margin-top:20px"><a class="project-link" href="index.html#portfolio">← Volver al portfolio</a></p>
+  </section>
+
+  <footer class="footer">
+    <div class="container footer-row">
+      <div>
+        <div class="logo">W AGENCY</div>
+        <div class="tiny muted">© 2025 · Todos los derechos reservados</div>
+      </div>
+      <div class="tiny muted right">Hecho con HTML + CSS</div>
+    </div>
+  </footer>
+</div>
+</body>
+</html>

--- a/caso-proyecto5.html
+++ b/caso-proyecto5.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width" />
+  <title>Proyecto 5 - W AGENCY</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+<div class="app">
+  <header class="header">
+    <nav class="nav container">
+      <a href="index.html" class="logo">W AGENCY</a>
+      <ul class="links">
+        <li><a href="index.html#servicios">Servicios</a></li>
+        <li><a href="index.html#portfolio">Portfolio</a></li>
+        <li><a href="index.html#contacto">Contacto</a></li>
+      </ul>
+      <a href="index.html#contacto" class="btn btn-outline">¡Quiero!</a>
+    </nav>
+  </header>
+
+  <section class="section container">
+    <h1 class="section-title">Proyecto 5</h1>
+    <p class="muted">Campaña de concientización con enfoque social y contenido audiovisual.</p>
+    <img src="https://images.unsplash.com/photo-1515168833906-d2a3b82b7270?auto=format&fit=crop&w=1200&q=80" alt="Proyecto 5" style="width:100%;border-radius:16px;margin:20px 0;">
+    <div class="grid">
+      <div class="card">
+        <div class="card-title">Desafío</div>
+        <p class="card-text">El objetivo era viralizar un mensaje social y sumar donaciones en pocos días.</p>
+      </div>
+      <div class="card">
+        <div class="card-title">Estrategia</div>
+        <p class="card-text">Produjimos videos emotivos y activamos una red de microinfluencers para amplificar el mensaje.</p>
+      </div>
+      <div class="card">
+        <div class="card-title">Resultados</div>
+        <p class="card-text">Se alcanzaron 2 millones de visualizaciones y se superó la meta de recaudación en un 80%.</p>
+      </div>
+    </div>
+    <p class="muted" style="margin-top:20px"><a class="project-link" href="index.html#portfolio">← Volver al portfolio</a></p>
+  </section>
+
+  <footer class="footer">
+    <div class="container footer-row">
+      <div>
+        <div class="logo">W AGENCY</div>
+        <div class="tiny muted">© 2025 · Todos los derechos reservados</div>
+      </div>
+      <div class="tiny muted right">Hecho con HTML + CSS</div>
+    </div>
+  </footer>
+</div>
+</body>
+</html>

--- a/caso-proyecto6.html
+++ b/caso-proyecto6.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width" />
+  <title>Proyecto 6 - W AGENCY</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+<div class="app">
+  <header class="header">
+    <nav class="nav container">
+      <a href="index.html" class="logo">W AGENCY</a>
+      <ul class="links">
+        <li><a href="index.html#servicios">Servicios</a></li>
+        <li><a href="index.html#portfolio">Portfolio</a></li>
+        <li><a href="index.html#contacto">Contacto</a></li>
+      </ul>
+      <a href="index.html#contacto" class="btn btn-outline">¡Quiero!</a>
+    </nav>
+  </header>
+
+  <section class="section container">
+    <h1 class="section-title">Proyecto 6</h1>
+    <p class="muted">Automatización de emails y optimización de embudos de venta.</p>
+    <img src="https://images.unsplash.com/photo-1504805572947-34fad45aed93?auto=format&fit=crop&w=1200&q=80" alt="Proyecto 6" style="width:100%;border-radius:16px;margin:20px 0;">
+    <div class="grid">
+      <div class="card">
+        <div class="card-title">Desafío</div>
+        <p class="card-text">El cliente quería recuperar carritos abandonados y mejorar la fidelización.</p>
+      </div>
+      <div class="card">
+        <div class="card-title">Estrategia</div>
+        <p class="card-text">Implementamos flujos automatizados, segmentación avanzada y pruebas A/B en asuntos.</p>
+      </div>
+      <div class="card">
+        <div class="card-title">Resultados</div>
+        <p class="card-text">La tasa de apertura subió al 45% y se recuperó un 20% de carritos abandonados.</p>
+      </div>
+    </div>
+    <p class="muted" style="margin-top:20px"><a class="project-link" href="index.html#portfolio">← Volver al portfolio</a></p>
+  </section>
+
+  <footer class="footer">
+    <div class="container footer-row">
+      <div>
+        <div class="logo">W AGENCY</div>
+        <div class="tiny muted">© 2025 · Todos los derechos reservados</div>
+      </div>
+      <div class="tiny muted right">Hecho con HTML + CSS</div>
+    </div>
+  </footer>
+</div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,9 @@
       <ul class="links">
         <li><a href="#servicios">Servicios</a></li>
         <li><a href="#portfolio">Portfolio</a></li>
+        <li><a href="#clientes">Clientes</a></li>
         <li><a href="#planes">Planes</a></li>
+        <li><a href="#testimonios">Testimonios</a></li>
         <li><a href="#contacto">Contacto</a></li>
       </ul>
       <a href="#contacto" class="btn btn-outline">¡Quiero!</a>
@@ -106,7 +108,7 @@
         <div class="card-body">
           <h3 class="project-title">Proyecto 1</h3>
           <p class="card-text">Descripción corta del proyecto y resultados logrados.</p>
-          <a class="project-link" href="#">Ver caso</a>
+          <a class="project-link" href="caso-proyecto1.html">Ver caso</a>
         </div>
       </article>
       <article class="card card-project">
@@ -114,7 +116,7 @@
         <div class="card-body">
           <h3 class="project-title">Proyecto 2</h3>
           <p class="card-text">Descripción corta del proyecto y resultados logrados.</p>
-          <a class="project-link" href="#">Ver caso</a>
+          <a class="project-link" href="caso-proyecto2.html">Ver caso</a>
         </div>
       </article>
       <article class="card card-project">
@@ -122,7 +124,7 @@
         <div class="card-body">
           <h3 class="project-title">Proyecto 3</h3>
           <p class="card-text">Descripción corta del proyecto y resultados logrados.</p>
-          <a class="project-link" href="#">Ver caso</a>
+          <a class="project-link" href="caso-proyecto3.html">Ver caso</a>
         </div>
       </article>
       <article class="card card-project">
@@ -130,7 +132,7 @@
         <div class="card-body">
           <h3 class="project-title">Proyecto 4</h3>
           <p class="card-text">Descripción corta del proyecto y resultados logrados.</p>
-          <a class="project-link" href="#">Ver caso</a>
+          <a class="project-link" href="caso-proyecto4.html">Ver caso</a>
         </div>
       </article>
       <article class="card card-project">
@@ -138,7 +140,7 @@
         <div class="card-body">
           <h3 class="project-title">Proyecto 5</h3>
           <p class="card-text">Descripción corta del proyecto y resultados logrados.</p>
-          <a class="project-link" href="#">Ver caso</a>
+          <a class="project-link" href="caso-proyecto5.html">Ver caso</a>
         </div>
       </article>
       <article class="card card-project">
@@ -146,9 +148,22 @@
         <div class="card-body">
           <h3 class="project-title">Proyecto 6</h3>
           <p class="card-text">Descripción corta del proyecto y resultados logrados.</p>
-          <a class="project-link" href="#">Ver caso</a>
+          <a class="project-link" href="caso-proyecto6.html">Ver caso</a>
         </div>
       </article>
+    </div>
+  </section>
+
+  <section id="clientes" class="section container">
+    <h2 class="section-title">Clientes</h2>
+    <p class="muted">Algunas marcas que confiaron en nosotros.</p>
+    <div class="logos">
+      <img src="https://www.logo.wine/a/logo/Google/Google-Logo.wine.svg" alt="Google" />
+      <img src="https://upload.wikimedia.org/wikipedia/commons/0/08/Netflix_2015_logo.svg" alt="Netflix" />
+      <img src="https://upload.wikimedia.org/wikipedia/commons/a/a9/Amazon_logo.svg" alt="Amazon" />
+      <img src="https://upload.wikimedia.org/wikipedia/commons/5/51/Facebook_f_logo_%282019%29.svg" alt="Meta" />
+      <img src="https://upload.wikimedia.org/wikipedia/commons/5/5f/Spotify_logo_with_text.svg" alt="Spotify" />
+      <img src="https://upload.wikimedia.org/wikipedia/commons/2/26/Intel_logo_%282020%2C_dark_blue%29.svg" alt="Intel" />
     </div>
   </section>
 
@@ -188,6 +203,31 @@
           <li>Soporte prioritario</li>
         </ul>
         <a href="#contacto" class="btn">Solicitar</a>
+      </div>
+    </div>
+  </section>
+
+  <section id="testimonios" class="section container">
+    <h2 class="section-title">Testimonios</h2>
+    <p class="muted">Lo que dicen nuestros clientes.</p>
+    <div class="grid testimonials">
+      <div class="card">
+        <img src="https://randomuser.me/api/portraits/women/68.jpg" alt="Ana López" class="avatar" />
+        <div class="name">Ana López</div>
+        <div class="role">CEO FitLife</div>
+        <p class="card-text">Trabajar con W Agency incrementó nuestras ventas en tiempo récord.</p>
+      </div>
+      <div class="card">
+        <img src="https://randomuser.me/api/portraits/men/32.jpg" alt="Carlos Pérez" class="avatar" />
+        <div class="name">Carlos Pérez</div>
+        <div class="role">Founder TechX</div>
+        <p class="card-text">Su equipo se compromete y ofrece soluciones creativas.</p>
+      </div>
+      <div class="card">
+        <img src="https://randomuser.me/api/portraits/men/85.jpg" alt="Luis Gómez" class="avatar" />
+        <div class="name">Luis Gómez</div>
+        <div class="role">CMO Gamer Fest</div>
+        <p class="card-text">La campaña superó todas nuestras expectativas.</p>
       </div>
     </div>
   </section>

--- a/styles.css
+++ b/styles.css
@@ -74,3 +74,14 @@ textarea{min-height:120px;resize:vertical}
 .footer{border-top:1px solid var(--border);background:#fff}
 .footer-row{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap;padding:26px 0}
 .right{text-align:right}
+
+/* Logos */
+.logos{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:24px;align-items:center;margin-top:18px}
+.logos img{max-width:100%;opacity:.8;transition:.2s}
+.logos img:hover{opacity:1}
+
+/* Testimonials */
+.testimonials .card{display:flex;flex-direction:column;align-items:flex-start;gap:8px}
+.testimonials .avatar{width:56px;height:56px;border-radius:50%;object-fit:cover}
+.testimonials .name{font-weight:700;color:var(--primary)}
+.testimonials .role{font-size:14px;color:var(--muted)}


### PR DESCRIPTION
## Summary
- Expand navigation with links to new sections
- Add clients logo showcase and testimonial cards
- Link portfolio items to dedicated case-study pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae34f772cc832da66ce4d18b5b749f